### PR TITLE
Add a sitemap to the blog site 

### DIFF
--- a/mysite/blog/sitemaps.py
+++ b/mysite/blog/sitemaps.py
@@ -1,0 +1,13 @@
+from django.contrib.sitemaps import Sitemap
+from .models import Post
+
+
+class PostSitemap(Sitemap):
+    changefreq = "weekly"
+    priority = 0.9
+
+    def items(self):
+        return Post.published.all()
+
+    def lastmod(self, obj):
+        return obj.updated

--- a/mysite/mysite/settings.py
+++ b/mysite/mysite/settings.py
@@ -28,7 +28,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-
+SITE_ID = 2
 # Application definition
 
 INSTALLED_APPS = [
@@ -40,6 +40,8 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "blog.apps.BlogConfig",
     "taggit",
+    "django.contrib.sites",
+    "django.contrib.sitemaps",
 ]
 
 MIDDLEWARE = [

--- a/mysite/mysite/urls.py
+++ b/mysite/mysite/urls.py
@@ -16,8 +16,20 @@ Including another URLconf
 
 from django.urls import path, include
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
+from blog.sitemaps import PostSitemap
+
+sitemaps = {
+    "posts": PostSitemap,
+}
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("blog/", include("blog.urls", namespace="blog")),
+    path(
+        "sitemap.xml",
+        sitemap,
+        {"sitemaps": sitemaps},
+        name="django.contrib.sitemaps.views.sitemap",
+    ),
 ]


### PR DESCRIPTION
- sitemap is an XML file that tells search engines the pages of the website, their relevance, and how frequently they are updated.
- sitemap will make the site more visible in search engine rankings.